### PR TITLE
Increase Nginx max body size to 1G

### DIFF
--- a/senex/buildold.py
+++ b/senex/buildold.py
@@ -158,7 +158,7 @@ def get_nginx_location_block(dir_name, port):
         proxy_set_header        X-Real-IP $remote_addr;
         proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header        X-Forwarded-Proto $scheme;
-        client_max_body_size    10m;
+        client_max_body_size    1000m;
         client_body_buffer_size 128k;
         proxy_connect_timeout   60s;
         proxy_send_timeout      90s;


### PR DESCRIPTION
Used to be 10M, which is too small and results in 413 errors when a 20M
file upload is attempted.